### PR TITLE
Change annealing format

### DIFF
--- a/src/braket/ir/annealing/problem.py
+++ b/src/braket/ir/annealing/problem.py
@@ -33,13 +33,25 @@ class Problem(BaseModel):
 
     Attributes:
         - type: The type of problem; can be either "QUBO" or "ISING"
-        = linear: Linear terms of the model.
-        - quadratic: Quadratic terms of the model.
+        - linear: Linear coefficients of the model, expressed as a map of term
+            to coefficient. For example,
+                0.3 * x_0 - 0.3 * x_4
+            is expressed as
+                {0: 0.3, 4: -0.3}
+        - quadratic: Quadratic coefficients of the model, expressed as a map of
+            the first variable in the term to a map of the second variable to the
+            corresponding quadratic term's coefficient. For example,
+                0.667 * x_0 * x_5 + 3 * x_0 * x_6 + 0.1 * x_2 * x_4
+            is expressed as
+                {0: {5: 0.667, 6: 3}, 2: {4: 0.1}}
 
     Examples:
-        >>> Problem(type=ProblemType.QUBO, linear={0: 0.3, 4: -0.3}, quadratic={(0, 5): 0.667})
+        >>> Problem(type=ProblemType.QUBO,
+        >>>         linear={0: 0.3, 4: -0.3},
+        >>>         quadratic={0: {5: 0.667, 6: 3}, 2: {4: 0.1}})
     """
 
     type: ProblemType
     linear: Dict[conint(ge=0), float]
     quadratic: Dict[Tuple[conint(ge=0), conint(ge=0)], float]
+    quadratic: Dict[conint(ge=0), Dict[conint(ge=0), float]]

--- a/test/braket/ir/annealing/test_problem.py
+++ b/test/braket/ir/annealing/test_problem.py
@@ -20,26 +20,25 @@ def test_creation():
     problem = Problem(
         type=ProblemType.QUBO,
         linear={0: 0.3333, 1: -0.333, 4: -0.333, 5: 0.333},
-        quadratic={(0, 4): 0.667, (0, 5): -1, (1, 4): 0.667, (1, 5): 0.667},
+        quadratic={0: {5: 0.667, 6: 3}, 2: {4: 0.1}},
     )
     assert problem.type == ProblemType.QUBO
     assert problem.linear == {0: 0.3333, 1: -0.333, 4: -0.333, 5: 0.333}
-    assert problem.quadratic == {(0, 4): 0.667, (0, 5): -1, (1, 4): 0.667, (1, 5): 0.667}
+    assert problem.quadratic == {0: {5: 0.667, 6: 3}, 2: {4: 0.1}}
+    assert Problem.parse_raw(problem.json()) == problem
 
 
 @pytest.mark.xfail(raises=ValidationError)
 def test__missing_type():
     Problem(
         linear={0: 0.3333, 1: -0.333, 4: -0.333, 5: 0.333},
-        quadratic={(0, 4): 0.667, (0, 5): -1, (1, 4): 0.667, (1, 5): 0.667},
+        quadratic={0: {5: 0.667, 6: 3}, 2: {4: 0.1}},
     )
 
 
 @pytest.mark.xfail(raises=ValidationError)
 def test_missing_linear():
-    Problem(
-        type=ProblemType.QUBO, quadratic={(0, 4): 0.667, (0, 5): -1, (1, 4): 0.667, (1, 5): 0.667}
-    )
+    Problem(type=ProblemType.QUBO, quadratic={0: {5: 0.667, 6: 3}, 2: {4: 0.1}})
 
 
 @pytest.mark.xfail(raises=ValidationError)


### PR DESCRIPTION
Tuples are not valid keys in JSON, so quadratic terms are now expressed
as dict of first variable to dict of second variable to coefficient.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
[build_files.tar.gz](https://github.com/aws/braket-python-ir/files/4078984/build_files.tar.gz)
