### PR TITLE
Add __version__ command

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,6 +3,4 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence, these accounts
 # will be requested forreview when someone opens a pull request.
-*   @floralph
-*   @avawang1
-*   @speller26
+*   @floralph @avawang1 @speller26

--- a/README.md
+++ b/README.md
@@ -18,6 +18,19 @@ Amazon Braket Python IR is an open source library that contains all the intermed
  pip install -e "braket-python-ir[test]"
  ```
 
+You can check your currently installed version of `braket-python-ir` with `pip show`:
+
+```bash
+pip show braket-python-ir
+```
+
+or alternatively from within Python:
+
+```
+>>> from braket import ir
+>>> ir.__version__
+```
+
 ## Usage
 There are currently two types of IR, including jacqd (JsonAwsQuantumCircuitDescription) and annealing. See below for their usage.
 

--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,12 @@
 
 from setuptools import find_namespace_packages, setup
 
+with open("src/braket/ir/_version.py") as f:
+    version = f.readlines()[-1].split()[-1].strip("\"'")
+
 setup(
     name="braket-ir",
-    version="0.2.4",
+    version=version,
     license="Apache License 2.0",
     python_requires=">= 3.7",
     packages=find_namespace_packages(where="src", exclude=("test",)),

--- a/src/braket/ir/__init__.py
+++ b/src/braket/ir/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2019-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+from ._version import __version__

--- a/src/braket/ir/_version.py
+++ b/src/braket/ir/_version.py
@@ -1,0 +1,18 @@
+# Copyright 2019-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+"""Version information.
+   Version number (major.minor.patch[-label])
+"""
+
+__version__ = "0.2.5"


### PR DESCRIPTION
Customers can now check IR version from Python:

```
>>> from braket import ir
>>> ir.__version__

0.2.5
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
