### PR TITLE
Remove ProblemType from annealing task result and make some attribute…

### DIFF
--- a/src/braket/task_result/annealing_task_result_v1.py
+++ b/src/braket/task_result/annealing_task_result_v1.py
@@ -15,7 +15,6 @@ from typing import List, Optional
 
 from pydantic import Field, conint, conlist
 
-from braket.ir.annealing import ProblemType
 from braket.schema_common.schema_base import BraketSchemaBase, BraketSchemaHeader
 from braket.task_result.additional_metadata import AdditionalMetadata
 from braket.task_result.task_metadata_v1 import TaskMetadata
@@ -28,13 +27,13 @@ class AnnealingTaskResult(BraketSchemaBase):
     Attributes:
         braketSchemaHeader (BraketSchemaHeader): Schema header. Users do not need
             to set this value. Only default is allowed.
-        solutions (List[int]): Solutions of task result
+        solutions (List[int]): Solutions of task result. Default is `None`.
         solutionCounts (List[int]): The number of times the solutions occurred.
-            Default is None
-        values (List[float]): Output or energy of the solutions
-        variableCount (int): The number of variables
-        taskMetadata (TaskMetadata): The task metadata
-        additionalMetadata (AdditionalMetadata): Additional metadata of the task
+            Default is `None`.
+        values (List[float]): Output or energy of the solutions. Default is `None`.
+        variableCount (int): The number of variables. Default is `None`.
+        taskMetadata (TaskMetadata): The task metadata.
+        additionalMetadata (AdditionalMetadata): Additional metadata of the task.
 
     """
 
@@ -44,10 +43,9 @@ class AnnealingTaskResult(BraketSchemaBase):
     braketSchemaHeader: BraketSchemaHeader = Field(
         default=_ANNEALING_TASK_RESULT_HEADER, const=_ANNEALING_TASK_RESULT_HEADER
     )
-    solutions: List[conlist(conint(ge=-1, le=3), min_items=1)]
+    solutions: Optional[List[conlist(conint(ge=-1, le=3), min_items=1)]]
     solutionCounts: Optional[List[conint(ge=0)]]
-    values: List[float]
-    variableCount: conint(ge=0)
-    problemType: ProblemType
+    values: Optional[List[float]]
+    variableCount: Optional[conint(ge=0)]
     taskMetadata: TaskMetadata
     additionalMetadata: AdditionalMetadata

--- a/test/braket/task_result/test_annealing_task_result_v1.py
+++ b/test/braket/task_result/test_annealing_task_result_v1.py
@@ -14,7 +14,6 @@
 import pytest
 from pydantic import ValidationError
 
-from braket.ir.annealing import ProblemType
 from braket.task_result.annealing_task_result_v1 import AnnealingTaskResult
 
 
@@ -38,11 +37,6 @@ def variable_count():
     return 5
 
 
-@pytest.fixture
-def problem_type():
-    return ProblemType.QUBO
-
-
 @pytest.mark.xfail(raises=ValidationError)
 def test_missing_properties():
     AnnealingTaskResult()
@@ -55,7 +49,6 @@ def test_correct_result(
     solutions,
     solution_counts,
     variable_count,
-    problem_type,
 ):
     result = AnnealingTaskResult(
         values=values,
@@ -64,7 +57,6 @@ def test_correct_result(
         variableCount=variable_count,
         taskMetadata=task_metadata,
         additionalMetadata=additional_metadata_annealing,
-        problemType=problem_type,
     )
     assert result.values == values
     assert result.solutions == solutions
@@ -72,7 +64,6 @@ def test_correct_result(
     assert result.variableCount == variable_count
     assert result.taskMetadata == task_metadata
     assert result.additionalMetadata == additional_metadata_annealing
-    assert result.problemType == problem_type
     assert AnnealingTaskResult.parse_raw(result.json()) == result
     assert result == AnnealingTaskResult.parse_raw_schema(result.json())
 
@@ -86,7 +77,6 @@ def test_incorrect_header(
     solutions,
     solution_counts,
     variable_count,
-    problem_type,
 ):
     AnnealingTaskResult(
         braketSchemaHeader=braket_schema_header,
@@ -96,7 +86,6 @@ def test_incorrect_header(
         variableCount=variable_count,
         taskMetadata=task_metadata,
         additionalMetadata=additional_metadata_annealing,
-        problemType=problem_type,
     )
 
 
@@ -109,7 +98,6 @@ def test_incorrect_solution_counts(
     solutions,
     solution_counts,
     variable_count,
-    problem_type,
 ):
     AnnealingTaskResult(
         values=values,
@@ -118,7 +106,6 @@ def test_incorrect_solution_counts(
         variableCount=variable_count,
         taskMetadata=task_metadata,
         additionalMetadata=additional_metadata_annealing,
-        problemType=problem_type,
     )
 
 
@@ -131,7 +118,6 @@ def test_incorrect_solutions(
     solutions,
     solution_counts,
     variable_count,
-    problem_type,
 ):
     AnnealingTaskResult(
         values=values,
@@ -140,7 +126,6 @@ def test_incorrect_solutions(
         variableCount=variable_count,
         taskMetadata=task_metadata,
         additionalMetadata=additional_metadata_annealing,
-        problemType=problem_type,
     )
 
 
@@ -153,7 +138,6 @@ def test_incorrect_values(
     solutions,
     solution_counts,
     variable_count,
-    problem_type,
 ):
     AnnealingTaskResult(
         values=values,
@@ -162,29 +146,6 @@ def test_incorrect_values(
         variableCount=variable_count,
         taskMetadata=task_metadata,
         additionalMetadata=additional_metadata_annealing,
-        problemType=problem_type,
-    )
-
-
-@pytest.mark.parametrize("problem_type", [(-2), ("HELLO")])
-@pytest.mark.xfail(raises=ValidationError)
-def test_incorrect_problem_type(
-    task_metadata,
-    additional_metadata_annealing,
-    values,
-    solutions,
-    solution_counts,
-    variable_count,
-    problem_type,
-):
-    AnnealingTaskResult(
-        values=values,
-        solutions=solutions,
-        solutionCounts=solution_counts,
-        variableCount=variable_count,
-        taskMetadata=task_metadata,
-        additionalMetadata=additional_metadata_annealing,
-        problemType=problem_type,
     )
 
 
@@ -197,7 +158,6 @@ def test_incorrect_variable_count(
     solutions,
     solution_counts,
     variable_count,
-    problem_type,
 ):
     AnnealingTaskResult(
         values=values,
@@ -206,5 +166,4 @@ def test_incorrect_variable_count(
         variableCount=variable_count,
         taskMetadata=task_metadata,
         additionalMetadata=additional_metadata_annealing,
-        problemType=problem_type,
     )


### PR DESCRIPTION
…s optional

*Issue #, if available:*

*Description of changes:*
* Remove ProblemType from annealing task result. The task result already has the annealing problem as "action", which has the problem type
* Make some attributes of annealing task result optional to support potentially only have task metadata and additional metadata for cancelled or failed tasks

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
