### PR TITLE
Change ResultType to ResultTypeValue to avoid conflicts/confusion

### DIFF
--- a/src/braket/ir/jaqcd/program_v1.py
+++ b/src/braket/ir/jaqcd/program_v1.py
@@ -94,6 +94,8 @@ GateInstructions = Union[
     ZZ,
 ]
 
+Results = Union[Amplitude, Expectation, Probability, Sample, StateVector, Variance]
+
 
 class Program(BraketSchemaBase):
     """
@@ -156,7 +158,5 @@ class Program(BraketSchemaBase):
     _PROGRAM_HEADER = BraketSchemaHeader(name="braket.ir.jaqcd.program", version="1")
     braketSchemaHeader: BraketSchemaHeader = Field(default=_PROGRAM_HEADER, const=_PROGRAM_HEADER)
     instructions: List[GateInstructions]
-    results: Optional[
-        List[Union[Amplitude, Expectation, Probability, Sample, StateVector, Variance]]
-    ]
+    results: Optional[List[Results]]
     basis_rotation_instructions: Optional[List[GateInstructions]]

--- a/src/braket/task_result/__init__.py
+++ b/src/braket/task_result/__init__.py
@@ -16,6 +16,6 @@ from braket.task_result.annealing_task_result_v1 import AnnealingTaskResult  # n
 from braket.task_result.dwave_metadata_v1 import DwaveMetadata, DwaveTiming  # noqa: F401
 from braket.task_result.gate_model_task_result_v1 import (  # noqa: F401
     GateModelTaskResult,
-    ResultType,
+    ResultTypeValue,
 )
 from braket.task_result.task_metadata_v1 import TaskMetadata  # noqa: F401

--- a/src/braket/task_result/gate_model_task_result_v1.py
+++ b/src/braket/task_result/gate_model_task_result_v1.py
@@ -15,22 +15,23 @@ from typing import Dict, List, Optional, Union
 
 from pydantic import BaseModel, Field, confloat, conint, conlist, constr
 
-from braket.ir.jaqcd.results import Expectation, Probability, Sample, StateVector, Variance
+from braket.ir.jaqcd.program_v1 import Results
 from braket.schema_common import BraketSchemaBase, BraketSchemaHeader
 from braket.task_result.additional_metadata import AdditionalMetadata
 from braket.task_result.task_metadata_v1 import TaskMetadata
 
 
-class ResultType(BaseModel):
+class ResultTypeValue(BaseModel):
     """
-    Result type of gate model task result.
+    Requested result type and value of gate model task result.
 
     Attributes:
-         type (Union[Expectation, Sample, StateVector, Variance, Probability]): The requested result
+         type (Union[Expectation, Sample, StateVector, Variance, Probability, Amplitude]): The
+            requested result type
          value (Union[List, float, Dict]): The value of the requested result
     """
 
-    type: Union[Expectation, Sample, StateVector, Variance, Probability]
+    type: Union[Results]
     value: Union[List, float, Dict]
 
 
@@ -42,15 +43,15 @@ class GateModelTaskResult(BraketSchemaBase):
         braketSchemaHeader (BraketSchemaHeader): Schema header. Users do not need
             to set this value. Only default is allowed.
         measurements (List[List[int]]: List of lists, where each list represents a shot
-            and each index of the list represents a qubit. Default is None.
+            and each index of the list represents a qubit. Default is `None`.
         measurementProbabilities (Dict[str, float]): A dictionary of probabilistic results.
             Key is the measurements in a big endian binary string.
             Value is the probability the measurement occurred.
-            Default is None.
+            Default is `None`.
         measuredQubits (List[int]): The indices of the measured qubits.
-            Indicates which qubits are in `measurements`. Default is None.
-        resultTypes (List[ResultType]): Requested result types and values of these results.
-
+            Indicates which qubits are in `measurements`. Default is `None`.
+        resultTypes (List[ResultTypeValue]): Requested result types and their values.
+            Default is `None`.
         taskMetadata (TaskMetadata): The task metadata
         additionalMetadata (AdditionalMetadata): Additional metadata of the task
     """
@@ -66,7 +67,7 @@ class GateModelTaskResult(BraketSchemaBase):
     measurementProbabilities: Optional[
         Dict[constr(regex="^[01]+$", min_length=1), confloat(ge=0, le=1)]
     ]
-    resultTypes: Optional[List[ResultType]]
+    resultTypes: Optional[List[ResultTypeValue]]
     measuredQubits: Optional[conlist(conint(ge=0), min_items=1)]
     taskMetadata: TaskMetadata
     additionalMetadata: AdditionalMetadata

--- a/test/braket/task_result/test_gate_model_task_result_v1.py
+++ b/test/braket/task_result/test_gate_model_task_result_v1.py
@@ -15,7 +15,7 @@ import pytest
 from pydantic import ValidationError
 
 from braket.ir.jaqcd.results import Probability
-from braket.task_result.gate_model_task_result_v1 import GateModelTaskResult, ResultType
+from braket.task_result.gate_model_task_result_v1 import GateModelTaskResult, ResultTypeValue
 
 
 @pytest.fixture
@@ -36,8 +36,8 @@ def measurement_probabilities():
 @pytest.fixture
 def result_types():
     return [
-        ResultType(type=Probability(targets=[0]), value=[0.5, 0.5]),
-        ResultType(type=Probability(targets=[1]), value=[0.5, 0.5]),
+        ResultTypeValue(type=Probability(targets=[0]), value=[0.5, 0.5]),
+        ResultTypeValue(type=Probability(targets=[1]), value=[0.5, 0.5]),
     ]
 
 
@@ -158,9 +158,9 @@ def test_incorrect_result_types(
 
 @pytest.mark.xfail(raises=ValidationError)
 def test_incorrect_result_type_attribute_type():
-    ResultType(type={"type": "unknown"}, value=[0.5, 0.5])
+    ResultTypeValue(type={"type": "unknown"}, value=[0.5, 0.5])
 
 
 @pytest.mark.xfail(raises=ValidationError)
 def test_incorrect_result_type_attribute_value():
-    ResultType(type={"type": "unknown"}, value=1)
+    ResultTypeValue(type={"type": "unknown"}, value=1)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Change ResultType to ResultTypeValue to avoid conflicts/confusion
* Added variable to represent set of result types allowed

[build_files.tar.gz](https://github.com/aws/braket-python-ir/files/4967425/build_files.tar.gz)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
