### PR TITLE
Adding schema for devices

### DIFF
--- a/src/braket/device_schema/annealing_model_parameters_v1.py
+++ b/src/braket/device_schema/annealing_model_parameters_v1.py
@@ -1,0 +1,31 @@
+# Copyright 2019-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+
+from pydantic import Field
+
+from braket.device_schema.d_wave_parameters_v1 import DWaveParameters
+from braket.schema_common import BraketSchemaBase, BraketSchemaHeader
+
+
+class AnnealingModelParameters(BraketSchemaBase):
+    """
+    This is the schema to validate the parameters provided for d-wave annealing model
+
+    """
+
+    _PROGRAM_HEADER = BraketSchemaHeader(
+        name="braket.device_schema.annealing_model_parameters", version="1"
+    )
+    braketSchemaHeader: BraketSchemaHeader = Field(default=_PROGRAM_HEADER, const=_PROGRAM_HEADER)
+    dWaveParameters: DWaveParameters

--- a/src/braket/device_schema/d_wave_device_capabilities_v1.py
+++ b/src/braket/device_schema/d_wave_device_capabilities_v1.py
@@ -1,0 +1,29 @@
+# Copyright 2019-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+from pydantic import Field
+
+from braket.device_schema.annealing_model_parameters_v1 import AnnealingModelParameters
+from braket.device_schema.d_wave_device_properties_v1 import DWaveDeviceProperties
+from braket.device_schema.device_capabilities_v1 import DeviceCapabilities
+from braket.schema_common import BraketSchemaHeader
+
+
+class DWaveDeviceCapabilities(DeviceCapabilities):
+
+    _PROGRAM_HEADER = BraketSchemaHeader(
+        name="braket.device_schema.d_wave_device_capabilities", version="1"
+    )
+    braketSchemaHeader: BraketSchemaHeader = Field(default=_PROGRAM_HEADER, const=_PROGRAM_HEADER)
+    device: DWaveDeviceProperties
+    deviceParameters: AnnealingModelParameters

--- a/src/braket/device_schema/d_wave_device_properties_v1.py
+++ b/src/braket/device_schema/d_wave_device_properties_v1.py
@@ -1,0 +1,34 @@
+from typing import List
+
+from pydantic import Field
+
+from braket.schema_common import BraketSchemaBase, BraketSchemaHeader
+
+
+class DWaveDeviceProperties(BraketSchemaBase):
+    _PROGRAM_HEADER = BraketSchemaHeader(
+        name="braket.device_schema.d_wave_device_properties", version="1"
+    )
+    braketSchemaHeader: BraketSchemaHeader = Field(default=_PROGRAM_HEADER, const=_PROGRAM_HEADER)
+    annealingOffsetStep: float
+    annealingOffsetStepPhi0: float
+    annealingOffsetRanges: List[List[float]]
+    annealingDurationRange: List[int]
+    couplers: List[List[int]]
+    defaultAnnealingDuration: int
+    defaultProgrammingThermalizationDuration: int
+    defaultReadoutThermalizationDuration: int
+    extendedJRange: List[int]
+    hGainScheduleRange: List[int]
+    hRange: List[int]
+    jRange: List[int]
+    maximumAnnealingSchedulePoints: int
+    maximumHGainSchedulePoints: int
+    perQubitCouplingRange: List[int]
+    programmingThermalizationDurationRange: List[int]
+    qubits: List[int]
+    qubitCount: int
+    quotaConversionRate: int
+    readoutThermalizationDurationRange: List[int]
+    taskRunDurationRange: List[int]
+    topology: dict

--- a/src/braket/device_schema/d_wave_parameters_v1.py
+++ b/src/braket/device_schema/d_wave_parameters_v1.py
@@ -1,0 +1,41 @@
+from enum import Enum
+from typing import List, Optional
+
+from pydantic import Field
+
+from braket.schema_common import BraketSchemaBase, BraketSchemaHeader
+
+
+class PostProcessingType(str, Enum):
+    """
+    The type of processing for d wave.
+    """
+
+    RAW = "raw"
+    HISTOGRAM = "histogram"
+
+
+class DWaveParameters(BraketSchemaBase):
+    """
+    This is the description of the d-wave parameters
+    """
+
+    _PROGRAM_HEADER = BraketSchemaHeader(name="braket.device_schema.d_wave_parameters", version="1")
+    braketSchemaHeader: BraketSchemaHeader = Field(default=_PROGRAM_HEADER, const=_PROGRAM_HEADER)
+    annealingOffsets: Optional[List[int]]
+    annealingSchedule: Optional[List[List[int]]]
+    annealingDuration: Optional[int] = Field(gt=1)
+    autoScale: Optional[bool]
+    beta: Optional[int]
+    chains: Optional[List[List[int]]]
+    compensateFluxDrift: Optional[bool]
+    fluxBiases: Optional[List[int]]
+    initialState: Optional[List[int]]
+    maxResults: Optional[int] = Field(gt=1)
+    postprocessingType: Optional[PostProcessingType]
+    programmingThermalizationDuration: Optional[int]
+    readoutThermalizationDuration: Optional[int]
+    reduceIntersampleCorrelation: Optional[bool]
+    reinitializeState: Optional[bool]
+    resultFormat: Optional[str]
+    spinReversalTransformCount: Optional[int] = Field(gt=0)

--- a/src/braket/device_schema/device_action_properties_v1.py
+++ b/src/braket/device_schema/device_action_properties_v1.py
@@ -1,0 +1,33 @@
+# Copyright 2019-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+from enum import Enum
+from typing import List
+
+from pydantic import Field
+
+from braket.schema_common import BraketSchemaBase, BraketSchemaHeader
+
+
+class DeviceActionType(str, Enum):
+    JAQCD = "braket.ir.jaqcd.program"
+    ANNEALING = "braket.ir.annealing.problem"
+
+
+class DeviceActionProperties(BraketSchemaBase):
+    _PROGRAM_HEADER = BraketSchemaHeader(
+        name="braket.device_schema.device_action_properties", version="1"
+    )
+    braketSchemaHeader: BraketSchemaHeader = Field(default=_PROGRAM_HEADER, const=_PROGRAM_HEADER)
+    version: List[str]
+    actionType: DeviceActionType

--- a/src/braket/device_schema/device_capabilities_v1.py
+++ b/src/braket/device_schema/device_capabilities_v1.py
@@ -1,0 +1,37 @@
+# Copyright 2019-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+from typing import Dict
+
+from pydantic import Field
+
+from braket.device_schema.device_action_properties_v1 import (
+    DeviceActionProperties,
+    DeviceActionType,
+)
+from braket.device_schema.device_paradigm_properties_v1 import DeviceParadigmProperties
+from braket.device_schema.device_parameters_v1 import DeviceParameters
+from braket.device_schema.device_service_properties_v1 import DeviceServiceProperties
+from braket.schema_common import BraketSchemaBase, BraketSchemaHeader
+
+
+class DeviceCapabilities(BraketSchemaBase):
+
+    _PROGRAM_HEADER = BraketSchemaHeader(
+        name="braket.device_schema.device_capabilities", version="1"
+    )
+    braketSchemaHeader: BraketSchemaHeader = Field(default=_PROGRAM_HEADER, const=_PROGRAM_HEADER)
+    service: DeviceServiceProperties
+    action: Dict[DeviceActionType, DeviceActionProperties]
+    paradigm: DeviceParadigmProperties
+    deviceParameters: DeviceParameters

--- a/src/braket/device_schema/device_connectivity_v1.py
+++ b/src/braket/device_schema/device_connectivity_v1.py
@@ -1,0 +1,25 @@
+# Copyright 2019-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+from pydantic import Field
+
+from braket.schema_common import BraketSchemaBase, BraketSchemaHeader
+
+
+class DeviceConnectivity(BraketSchemaBase):
+    _PROGRAM_HEADER = BraketSchemaHeader(
+        name="braket.device_schema.device_connectivity", version="1"
+    )
+    braketSchemaHeader: BraketSchemaHeader = Field(default=_PROGRAM_HEADER, const=_PROGRAM_HEADER)
+    fullyConnected = bool
+    connectivityGraph = dict

--- a/src/braket/device_schema/device_execution_window_v1.py
+++ b/src/braket/device_schema/device_execution_window_v1.py
@@ -1,0 +1,49 @@
+# Copyright 2019-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+from datetime import datetime
+from enum import Enum
+
+from pydantic import Field
+
+from braket.schema_common import BraketSchemaBase, BraketSchemaHeader
+
+
+class ExecutionDay(str, Enum):
+    """ The type of annealing problem.
+
+    QUBO: Quadratic Unconstrained Binary Optimization, with values 1 and 0
+    ISING: Ising model, with values +/-1
+    """
+
+    EVERYDAY = "Everyday"
+    WEEKDAYS = "Weekdays"
+    WEEKENDS = "Weekend"
+    MONDAY = "Monday"
+    TUESDAY = "Tuesday"
+    WEDNESDAY = "Wednesday"
+    THURSDAY = "Thursday"
+    FRIDAY = "Friday"
+    SATURDAY = "Saturday"
+    SUNDAY = "Sunday"
+
+
+class DeviceExecutionWindow(BraketSchemaBase):
+
+    _PROGRAM_HEADER = BraketSchemaHeader(
+        name="braket.device_schema.device_execution_window", version="1"
+    )
+    braketSchemaHeader: BraketSchemaHeader = Field(default=_PROGRAM_HEADER, const=_PROGRAM_HEADER)
+    executionDay: ExecutionDay
+    windowStartHour: datetime
+    windowEndHour: datetime

--- a/src/braket/device_schema/device_paradigm_properties_v1.py
+++ b/src/braket/device_schema/device_paradigm_properties_v1.py
@@ -1,0 +1,24 @@
+# Copyright 2019-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+from pydantic import Field
+
+from braket.schema_common import BraketSchemaBase, BraketSchemaHeader
+
+
+class DeviceParadigmProperties(BraketSchemaBase):
+
+    _PROGRAM_HEADER = BraketSchemaHeader(
+        name="braket.device_schema.device_paradigm_properties", version="1"
+    )
+    braketSchemaHeader: BraketSchemaHeader = Field(default=_PROGRAM_HEADER, const=_PROGRAM_HEADER)

--- a/src/braket/device_schema/device_parameters_v1.py
+++ b/src/braket/device_schema/device_parameters_v1.py
@@ -1,0 +1,13 @@
+from typing import Union
+
+from pydantic import Field
+
+from braket.device_schema.annealing_model_parameters_v1 import AnnealingModelParameters
+from braket.device_schema.gate_model_parameters_v1 import GateModelParameters
+from braket.schema_common import BraketSchemaBase, BraketSchemaHeader
+
+
+class DeviceParameters(BraketSchemaBase):
+    _PROGRAM_HEADER = BraketSchemaHeader(name="braket.device_schema.device_parameters", version="1")
+    braketSchemaHeader: BraketSchemaHeader = Field(default=_PROGRAM_HEADER, const=_PROGRAM_HEADER)
+    deviceParameters: Union[GateModelParameters, AnnealingModelParameters]

--- a/src/braket/device_schema/device_service_properties_v1.py
+++ b/src/braket/device_schema/device_service_properties_v1.py
@@ -1,0 +1,45 @@
+# Copyright 2019-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+from typing import List
+
+from pydantic import Field
+
+from braket.device_schema.device_execution_window_v1 import DeviceExecutionWindow
+from braket.schema_common import BraketSchemaBase, BraketSchemaHeader
+
+
+class DeviceServiceProperties(BraketSchemaBase):
+    """
+    Root object of the JsonAwsQuantumCircuitDescription IR.
+
+
+
+    Attributes:
+        braketSchemaHeader (BraketSchemaHeader): Schema header. Users do not need
+            to set this value. Only default is allowed.
+        instructions (List[GateInstructions]): List of instructions.
+        basis_rotation_instructions (List[GateInstructions]): List of instructions for
+            rotation to desired measurement bases. Default is None.
+        results (List[Union[Amplitude, Expectation, Probability, Sample, StateVector, Variance]]):
+            List of requested results. Default is None.
+
+    Examples:
+    """
+
+    _PROGRAM_HEADER = BraketSchemaHeader(
+        name="braket.device_schema.device_service_properties", version="1"
+    )
+    braketSchemaHeader: BraketSchemaHeader = Field(default=_PROGRAM_HEADER, const=_PROGRAM_HEADER)
+    executionWindows: List[DeviceExecutionWindow]
+    shots: int

--- a/src/braket/device_schema/gate_model_parameters_v1.py
+++ b/src/braket/device_schema/gate_model_parameters_v1.py
@@ -1,0 +1,10 @@
+from pydantic import Field
+
+from braket.schema_common import BraketSchemaBase, BraketSchemaHeader
+
+
+class GateModelParameters(BraketSchemaBase):
+    _PROGRAM_HEADER = BraketSchemaHeader(
+        name="braket.device_schema.gate_model_parameters", version="1"
+    )
+    braketSchemaHeader: BraketSchemaHeader = Field(default=_PROGRAM_HEADER, const=_PROGRAM_HEADER)

--- a/src/braket/device_schema/ion_q_device_capabilities_v1.py
+++ b/src/braket/device_schema/ion_q_device_capabilities_v1.py
@@ -1,0 +1,36 @@
+# Copyright 2019-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+from typing import Dict
+
+from pydantic import Field
+
+from braket.device_schema.device_action_properties_v1 import DeviceActionType
+from braket.device_schema.device_capabilities_v1 import DeviceCapabilities
+from braket.device_schema.device_service_properties_v1 import DeviceServiceProperties
+from braket.device_schema.ion_q_device_paradigm_properties_v1 import IonQDeviceParadigmProperties
+from braket.device_schema.ion_q_device_parameters_v1 import IonQDeviceParameters
+from braket.device_schema.jaqcd_device_action_properties_v1 import JaqcdDeviceActionProperties
+from braket.schema_common import BraketSchemaBase, BraketSchemaHeader
+
+
+class IonQDeviceCapabilities(DeviceCapabilities):
+
+    _PROGRAM_HEADER = BraketSchemaHeader(
+        name="braket.device_schema.ion_q_device_capabilities", version="1"
+    )
+    braketSchemaHeader: BraketSchemaHeader = Field(default=_PROGRAM_HEADER, const=_PROGRAM_HEADER)
+    service: DeviceServiceProperties
+    action: Dict[DeviceActionType, JaqcdDeviceActionProperties]
+    paradigm: IonQDeviceParadigmProperties
+    deviceParameters: IonQDeviceParameters

--- a/src/braket/device_schema/ion_q_device_paradigm_properties_v1.py
+++ b/src/braket/device_schema/ion_q_device_paradigm_properties_v1.py
@@ -1,0 +1,31 @@
+# Copyright 2019-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+from typing import List
+
+from pydantic import Field
+
+from braket.device_schema.device_connectivity_v1 import DeviceConnectivity
+from braket.device_schema.device_paradigm_properties_v1 import DeviceParadigmProperties
+from braket.schema_common import BraketSchemaHeader
+
+
+class IonQDeviceParadigmProperties(DeviceParadigmProperties):
+
+    _PROGRAM_HEADER = BraketSchemaHeader(
+        name="braket.device_schema.ion_q_device_paradigm_properties", version="1"
+    )
+    braketSchemaHeader: BraketSchemaHeader = Field(default=_PROGRAM_HEADER, const=_PROGRAM_HEADER)
+    connectivity: DeviceConnectivity
+    qubitCount: int
+    nativeGateSet: List[str]

--- a/src/braket/device_schema/ion_q_device_parameters_v1.py
+++ b/src/braket/device_schema/ion_q_device_parameters_v1.py
@@ -1,0 +1,12 @@
+from pydantic import Field
+
+from braket.device_schema.gate_model_parameters_v1 import GateModelParameters
+from braket.schema_common import BraketSchemaHeader
+
+
+class IonQDeviceParameters(GateModelParameters):
+    _PROGRAM_HEADER = BraketSchemaHeader(
+        name="braket.device_schema.ion_q_device_parameters", version="1"
+    )
+    braketSchemaHeader: BraketSchemaHeader = Field(default=_PROGRAM_HEADER, const=_PROGRAM_HEADER)
+    qubitCount: int = Field(gt=0, lt=12)

--- a/src/braket/device_schema/jaqcd_device_action_properties_v1.py
+++ b/src/braket/device_schema/jaqcd_device_action_properties_v1.py
@@ -1,0 +1,94 @@
+from typing import Dict, List, Optional, Union
+
+from pydantic import Field
+
+from braket.device_schema.device_action_properties_v1 import DeviceActionProperties
+from braket.ir.jaqcd.instructions import (
+    CY,
+    CZ,
+    XX,
+    XY,
+    YY,
+    ZZ,
+    CCNot,
+    CNot,
+    CPhaseShift,
+    CPhaseShift00,
+    CPhaseShift01,
+    CPhaseShift10,
+    CSwap,
+    H,
+    I,
+    ISwap,
+    PhaseShift,
+    PSwap,
+    Rx,
+    Ry,
+    Rz,
+    S,
+    Si,
+    Swap,
+    T,
+    Ti,
+    Unitary,
+    V,
+    Vi,
+    X,
+    Y,
+    Z,
+)
+from braket.ir.jaqcd.results import (
+    Amplitude,
+    Expectation,
+    Probability,
+    Sample,
+    StateVector,
+    Variance,
+)
+from braket.schema_common import BraketSchemaHeader
+
+GateInstructions = Union[
+    CCNot,
+    CNot,
+    CPhaseShift,
+    CPhaseShift00,
+    CPhaseShift01,
+    CPhaseShift10,
+    CSwap,
+    CY,
+    CZ,
+    H,
+    I,
+    ISwap,
+    PhaseShift,
+    PSwap,
+    Rx,
+    Ry,
+    Rz,
+    S,
+    Swap,
+    Si,
+    T,
+    Ti,
+    Unitary,
+    V,
+    Vi,
+    X,
+    XX,
+    XY,
+    Y,
+    YY,
+    Z,
+    ZZ,
+]
+
+Results = Union[Amplitude, Expectation, Probability, Sample, StateVector, Variance]
+
+
+class JaqcdDeviceActionProperties(DeviceActionProperties):
+    _PROGRAM_HEADER = BraketSchemaHeader(
+        name="braket.device_schema.jaqcd_device_action_properties", version="1"
+    )
+    braketSchemaHeader: BraketSchemaHeader = Field(default=_PROGRAM_HEADER, const=_PROGRAM_HEADER)
+    supportedOperations: List[GateInstructions]
+    supportedResultTypes: Optional[List[Results]]

--- a/src/braket/device_schema/rigetti_device_capabilities_v1.py
+++ b/src/braket/device_schema/rigetti_device_capabilities_v1.py
@@ -1,0 +1,38 @@
+# Copyright 2019-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+from typing import Dict
+
+from pydantic import Field
+
+from braket.device_schema.device_action_properties_v1 import DeviceActionType
+from braket.device_schema.device_capabilities_v1 import DeviceCapabilities
+from braket.device_schema.device_service_properties_v1 import DeviceServiceProperties
+from braket.device_schema.jaqcd_device_action_properties_v1 import JaqcdDeviceActionProperties
+from braket.device_schema.rigetti_device_paradigm_properties_v1 import (
+    RigettiDeviceParadigmProperties,
+)
+from braket.device_schema.rigetti_device_parameters_v1 import RigettiDeviceParameters
+from braket.schema_common import BraketSchemaHeader
+
+
+class RigettiDeviceCapabilities(DeviceCapabilities):
+
+    _PROGRAM_HEADER = BraketSchemaHeader(
+        name="braket.device_schema.rigetti_device_capabilities", version="1"
+    )
+    braketSchemaHeader: BraketSchemaHeader = Field(default=_PROGRAM_HEADER, const=_PROGRAM_HEADER)
+    service: DeviceServiceProperties
+    action: Dict[DeviceActionType, JaqcdDeviceActionProperties]
+    paradigm: RigettiDeviceParadigmProperties
+    deviceParameters: RigettiDeviceParameters

--- a/src/braket/device_schema/rigetti_device_paradigm_properties_v1.py
+++ b/src/braket/device_schema/rigetti_device_paradigm_properties_v1.py
@@ -1,0 +1,30 @@
+# Copyright 2019-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+from typing import List
+
+from pydantic import Field
+
+from braket.device_schema.device_connectivity_v1 import DeviceConnectivity
+from braket.schema_common import BraketSchemaBase, BraketSchemaHeader
+
+
+class RigettiDeviceParadigmProperties(BraketSchemaBase):
+
+    _PROGRAM_HEADER = BraketSchemaHeader(
+        name="braket.device_schema.rigetti_device_paradigm_properties", version="1"
+    )
+    braketSchemaHeader: BraketSchemaHeader = Field(default=_PROGRAM_HEADER, const=_PROGRAM_HEADER)
+    connectivity: DeviceConnectivity
+    qubitCount: int
+    nativeGateSet: List[str]

--- a/src/braket/device_schema/rigetti_device_parameters_v1.py
+++ b/src/braket/device_schema/rigetti_device_parameters_v1.py
@@ -1,0 +1,12 @@
+from pydantic import Field
+
+from braket.device_schema.gate_model_parameters_v1 import GateModelParameters
+from braket.schema_common import BraketSchemaHeader
+
+
+class RigettiDeviceParameters(GateModelParameters):
+    _PROGRAM_HEADER = BraketSchemaHeader(
+        name="braket.device_schema.rigetti_device_parameters", version="1"
+    )
+    braketSchemaHeader: BraketSchemaHeader = Field(default=_PROGRAM_HEADER, const=_PROGRAM_HEADER)
+    qubitCount: int = Field(gt=0, lt=32)

--- a/test/braket/device_schema/test_annealing_model_parameters_v1.py
+++ b/test/braket/device_schema/test_annealing_model_parameters_v1.py
@@ -1,0 +1,46 @@
+# Copyright 2019-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from braket.device_schema.annealing_model_parameters_v1 import AnnealingModelParameters
+from braket.device_schema.d_wave_parameters_v1 import DWaveParameters
+
+
+def test_valid():
+    input = (
+        '{"braketSchemaHeader": {"name": "braket.device_schema.d_wave_parameters", '
+        '"version": "1"}} '
+    )
+    d_wave = DWaveParameters.parse_raw_schema(input)
+    input_annealing_model = {
+        "braketSchemaHeader": {
+            "name": "braket.device_schema.annealing_model_parameters",
+            "version": "1",
+        },
+        "dWaveParameters": json.loads(d_wave.json()),
+    }
+    result = AnnealingModelParameters.parse_raw_schema(json.dumps(input_annealing_model))
+    assert result.dWaveParameters == d_wave
+
+
+@pytest.mark.xfail(raises=ValidationError)
+def test__invalid_attribute():
+    input = (
+        '{"braketSchemaHeader": {"name": "braket.device_schema.annealing_model_parameters", '
+        '"version": "1"}} '
+    )
+    AnnealingModelParameters.parse_raw_schema(input)

--- a/test/braket/device_schema/test_d_wave_device_capabilities_v1.py
+++ b/test/braket/device_schema/test_d_wave_device_capabilities_v1.py
@@ -1,0 +1,122 @@
+# Copyright 2019-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+import json
+import pdb
+
+import pytest
+from pydantic import ValidationError
+
+from braket.device_schema.d_wave_device_properties_v1 import DWaveDeviceProperties
+
+
+@pytest.fixture(scope="module")
+def valid_input():
+    input = {
+        "braketSchemaHeader": {
+            "name": "braket.device_schema.d_wave_device_capabilities",
+            "version": "1",
+        },
+        "device": {
+            "braketSchemaHeader": {
+                "name": "braket.device_schema.d_wave_device_properties",
+                "version": "1",
+            },
+            "annealingOffsetStep": 1.45,
+            "annealingOffsetStepPhi0": 1.45,
+            "annealingOffsetRanges": [[1.45, 1.45], [1.45, 1.45]],
+            "annealingDurationRange": [1, 2, 3],
+            "couplers": [[1, 2, 3], [1, 2, 3]],
+            "defaultAnnealingDuration": 1,
+            "defaultProgrammingThermalizationDuration": 1,
+            "defaultReadoutThermalizationDuration": 1,
+            "extendedJRange": [1, 2, 3],
+            "hGainScheduleRange": [1, 2, 3],
+            "hRange": [1, 2, 3],
+            "jRange": [1, 2, 3],
+            "maximumAnnealingSchedulePoints": 1,
+            "maximumHGainSchedulePoints": 1,
+            "perQubitCouplingRange": [1, 2, 3],
+            "programmingThermalizationDurationRange": [1, 2, 3],
+            "qubits": [1, 2, 3],
+            "qubitCount": 1,
+            "quotaConversionRate": 1,
+            "readoutThermalizationDurationRange": [1, 2, 3],
+            "taskRunDurationRange": [1, 2, 3],
+            "topology": {},
+        },
+        "service": {
+            "braketSchemaHeader": {
+                "name": "braket.device_schema.device_service_properties",
+                "version": "1",
+            },
+            "executionWindows": [
+                {
+                    "braketSchemaHeader": {
+                        "name": "braket.device_schema.device_execution_window",
+                        "version": "1",
+                    },
+                    "executionDay": "Everyday",
+                    "windowStartHour": "1966280412345.6789",
+                    "windowEndHour": "1966280414345.6789",
+                }
+            ],
+            "shots": 2,
+        },
+        "action": {
+            "braket.ir.jaqcd.program": {
+                "braketSchemaHeader": {
+                    "name": "braket.device_schema.device_action_properties",
+                    "version": "1",
+                },
+                "actionType": "braket.ir.jaqcd.program",
+                "version": ["1.0", "1.1"],
+            }
+        },
+        "paradigm": {
+            "braketSchemaHeader": {
+                "name": "braket.device_schema.device_paradigm_properties",
+                "version": "1",
+            }
+        },
+        "deviceParameters": {
+            "braketSchemaHeader": {
+                "name": "braket.device_schema.annealing_model_parameters",
+                "version": "1",
+            },
+            "dWaveParameters": {
+                "braketSchemaHeader": {
+                    "name": "braket.device_schema.d_wave_parameters",
+                    "version": "1",
+                }
+            },
+        },
+    }
+    return input
+
+
+def test_valid(valid_input):
+    result = DWaveDeviceProperties.parse_raw_schema(json.dumps(valid_input))
+    assert result.device.qubitCount == 1
+
+
+@pytest.mark.xfail(raises=ValidationError)
+def test__missing_schemaHeader(valid_input):
+    valid_input.pop("braketSchemaHeader")
+    DWaveDeviceProperties.parse_raw_schema(json.dumps(valid_input))
+
+
+@pytest.mark.xfail(raises=ValidationError)
+def test_missing_qubitCount(valid_input):
+    valid_input.pop("device")
+    DWaveDeviceProperties.parse_raw_schema(json.dumps(valid_input))

--- a/test/braket/device_schema/test_d_wave_device_properties_v1.py
+++ b/test/braket/device_schema/test_d_wave_device_properties_v1.py
@@ -1,0 +1,76 @@
+# Copyright 2019-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+import json
+import pdb
+
+import pytest
+from pydantic import ValidationError
+
+from braket.device_schema.d_wave_device_properties_v1 import DWaveDeviceProperties
+
+
+@pytest.fixture(scope="module")
+def valid_input():
+    input = {
+        "braketSchemaHeader": {
+            "name": "braket.device_schema.d_wave_device_properties",
+            "version": "1",
+        },
+        "annealingOffsetStep": 1.45,
+        "annealingOffsetStepPhi0": 1.45,
+        "annealingOffsetRanges": [[1.45, 1.45], [1.45, 1.45]],
+        "annealingDurationRange": [1, 2, 3],
+        "couplers": [[1, 2, 3], [1, 2, 3]],
+        "defaultAnnealingDuration": 1,
+        "defaultProgrammingThermalizationDuration": 1,
+        "defaultReadoutThermalizationDuration": 1,
+        "extendedJRange": [1, 2, 3],
+        "hGainScheduleRange": [1, 2, 3],
+        "hRange": [1, 2, 3],
+        "jRange": [1, 2, 3],
+        "maximumAnnealingSchedulePoints": 1,
+        "maximumHGainSchedulePoints": 1,
+        "perQubitCouplingRange": [1, 2, 3],
+        "programmingThermalizationDurationRange": [1, 2, 3],
+        "qubits": [1, 2, 3],
+        "qubitCount": 1,
+        "quotaConversionRate": 1,
+        "readoutThermalizationDurationRange": [1, 2, 3],
+        "taskRunDurationRange": [1, 2, 3],
+        "topology": {},
+    }
+    return input
+
+
+def test_valid(valid_input):
+    result = DWaveDeviceProperties.parse_raw_schema(json.dumps(valid_input))
+    assert result.qubitCount == 1
+
+
+@pytest.mark.xfail(raises=ValidationError)
+def test__missing_schemaHeader(valid_input):
+    valid_input.pop("braketSchemaHeader")
+    DWaveDeviceProperties.parse_raw_schema(json.dumps(valid_input))
+
+
+@pytest.mark.xfail(raises=ValidationError)
+def test__missing_qubitCount(valid_input):
+    valid_input.pop("qubitCount")
+    DWaveDeviceProperties.parse_raw_schema(json.dumps(valid_input))
+
+
+@pytest.mark.xfail(raises=ValidationError)
+def test__invalid_qubitcount(valid_input):
+    valid_input["qubitCount"] = "string"
+    DWaveDeviceProperties.parse_raw_schema(json.dumps(valid_input))

--- a/test/braket/device_schema/test_d_wave_parameters_v1.py
+++ b/test/braket/device_schema/test_d_wave_parameters_v1.py
@@ -1,0 +1,36 @@
+# Copyright 2019-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+import pytest
+from pydantic import ValidationError
+
+from braket.device_schema.d_wave_parameters_v1 import DWaveParameters
+
+
+def test_valid():
+    input = (
+        '{"braketSchemaHeader": {"name": "braket.device_schema.d_wave_parameters", '
+        '"version": "1"}} '
+    )
+    result = DWaveParameters.parse_raw_schema(input)
+    assert result.braketSchemaHeader.name == "braket.device_schema.d_wave_parameters"
+
+
+@pytest.mark.xfail(raises=ValidationError)
+def test__invalid_attribute():
+    input = (
+        '{"braketSchemaHeader": {"name": "braket.device_schema.d_wave_parameters", '
+        '"version": "1"}, "annealingOffsets": 1} '
+    )
+    # annealingOffsets should be List[int]
+    DWaveParameters.parse_raw_schema(input)

--- a/test/braket/device_schema/test_device_action_properties_v1.py
+++ b/test/braket/device_schema/test_device_action_properties_v1.py
@@ -1,0 +1,55 @@
+# Copyright 2019-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from braket.device_schema.device_action_properties_v1 import DeviceActionProperties
+
+
+@pytest.fixture(scope="module")
+def valid_input():
+    input = {
+        "braketSchemaHeader": {
+            "name": "braket.device_schema.device_action_properties",
+            "version": "1",
+        },
+        "actionType": "braket.ir.jaqcd.program",
+        "version": ["1.0", "1.1"],
+    }
+    return input
+
+
+def test_valid(valid_input):
+    result = DeviceActionProperties.parse_raw_schema(json.dumps(valid_input))
+    assert result.actionType == "braket.ir.jaqcd.program"
+
+
+@pytest.mark.xfail(raises=ValidationError)
+def test__missing_schemaHeader(valid_input):
+    valid_input.pop("braketSchemaHeader")
+    DeviceActionProperties.parse_raw_schema(json.dumps(valid_input))
+
+
+@pytest.mark.xfail(raises=ValidationError)
+def test__missing_actionType(valid_input):
+    valid_input.pop("actionType")
+    DeviceActionProperties.parse_raw_schema(json.dumps(valid_input))
+
+
+@pytest.mark.xfail(raises=ValidationError)
+def test__missing_version(valid_input):
+    valid_input.pop("version")
+    DeviceActionProperties.parse_raw_schema(json.dumps(valid_input))

--- a/test/braket/device_schema/test_device_capabilities_v1.py
+++ b/test/braket/device_schema/test_device_capabilities_v1.py
@@ -1,0 +1,154 @@
+# Copyright 2019-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+from typing import Dict
+
+from pydantic import Field
+
+from braket.device_schema.device_action_properties_v1 import (
+    DeviceActionProperties,
+    DeviceActionType,
+)
+from braket.device_schema.device_paradigm_properties_v1 import DeviceParadigmProperties
+from braket.device_schema.device_parameters_v1 import DeviceParameters
+from braket.device_schema.device_service_properties_v1 import DeviceServiceProperties
+from braket.schema_common import BraketSchemaBase, BraketSchemaHeader
+
+
+class DeviceCapabilities(BraketSchemaBase):
+
+    _PROGRAM_HEADER = BraketSchemaHeader(
+        name="braket.device_schema.device_capabilities", version="1"
+    )
+    braketSchemaHeader: BraketSchemaHeader = Field(default=_PROGRAM_HEADER, const=_PROGRAM_HEADER)
+    service: DeviceServiceProperties
+    action: Dict[DeviceActionType, DeviceActionProperties]
+    paradigm: DeviceParadigmProperties
+    deviceParameters: DeviceParameters
+
+
+# Copyright 2019-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+import json
+import pdb
+
+import pytest
+from pydantic import ValidationError
+
+from braket.device_schema.ion_q_device_capabilities_v1 import IonQDeviceCapabilities
+
+
+@pytest.fixture(scope="module")
+def valid_input():
+    input = {
+        "braketSchemaHeader": {"name": "braket.device_schema.device_capabilities", "version": "1",},
+        "service": {
+            "braketSchemaHeader": {
+                "name": "braket.device_schema.device_service_properties",
+                "version": "1",
+            },
+            "executionWindows": [
+                {
+                    "braketSchemaHeader": {
+                        "name": "braket.device_schema.device_execution_window",
+                        "version": "1",
+                    },
+                    "executionDay": "Everyday",
+                    "windowStartHour": "1966280412345.6789",
+                    "windowEndHour": "1966280414345.6789",
+                }
+            ],
+            "shots": 2,
+        },
+        "action": {
+            "braket.ir.jaqcd.program": {
+                "braketSchemaHeader": {
+                    "name": "braket.device_schema.device_action_properties",
+                    "version": "1",
+                },
+                "actionType": "braket.ir.jaqcd.program",
+                "version": ["1.0", "1.1"],
+            }
+        },
+        "paradigm": {
+            "braketSchemaHeader": {
+                "name": "braket.device_schema.device_paradigm_properties",
+                "version": "1",
+            }
+        },
+        "deviceParameters": {
+            "braketSchemaHeader": {
+                "name": "braket.device_schema.device_parameters",
+                "version": "1",
+            },
+            "deviceParameters": {
+                "braketSchemaHeader": {
+                    "name": "braket.device_schema.annealing_model_parameters",
+                    "version": "1",
+                },
+                "dWaveParameters": {
+                    "braketSchemaHeader": {
+                        "name": "braket.device_schema.d_wave_parameters",
+                        "version": "1",
+                    }
+                },
+            },
+        },
+    }
+    return input
+
+
+def test_valid(valid_input):
+    result = IonQDeviceCapabilities.parse_raw_schema(json.dumps(valid_input))
+    assert result.braketSchemaHeader.name == "braket.device_schema.device_capabilities"
+
+
+@pytest.mark.xfail(raises=ValidationError)
+def test__missing_schemaHeader(valid_input):
+    valid_input.pop("braketSchemaHeader")
+    IonQDeviceCapabilities.parse_raw_schema(json.dumps(valid_input))
+
+
+@pytest.mark.xfail(raises=ValidationError)
+def test_missing_paradigm(valid_input):
+    valid_input.pop("paradigm")
+    IonQDeviceCapabilities.parse_raw_schema(json.dumps(valid_input))
+
+
+@pytest.mark.xfail(raises=ValidationError)
+def test_missing_deviceParameters(valid_input):
+    valid_input.pop("deviceParameters")
+    IonQDeviceCapabilities.parse_raw_schema(json.dumps(valid_input))
+
+
+@pytest.mark.xfail(raises=ValidationError)
+def test_missing_action(valid_input):
+    valid_input.pop("action")
+    IonQDeviceCapabilities.parse_raw_schema(json.dumps(valid_input))
+
+
+@pytest.mark.xfail(raises=ValidationError)
+def test_missing_service(valid_input):
+    valid_input.pop("service")
+    IonQDeviceCapabilities.parse_raw_schema(json.dumps(valid_input))

--- a/test/braket/device_schema/test_device_connectivity_v1.py
+++ b/test/braket/device_schema/test_device_connectivity_v1.py
@@ -1,0 +1,53 @@
+# Copyright 2019-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+import json
+import pdb
+
+import pytest
+from pydantic import ValidationError
+
+from braket.device_schema.device_connectivity_v1 import DeviceConnectivity
+
+
+@pytest.fixture(scope="module")
+def valid_input():
+    input = {
+        "braketSchemaHeader": {"name": "braket.device_schema.device_connectivity", "version": "1",},
+        "fullyConnected": True,
+        "connectivityGraph": {"1": ["2", "3"]},
+    }
+    return input
+
+
+def test_valid(valid_input):
+    result = DeviceConnectivity.parse_raw_schema(json.dumps(valid_input))
+    assert result.fullyConnected
+
+
+@pytest.mark.xfail(raises=ValidationError)
+def test__missing_schemaHeader(valid_input):
+    valid_input.pop("braketSchemaHeader")
+    assert DeviceConnectivity.parse_raw_schema(json.dumps(valid_input))
+
+
+@pytest.mark.xfail(raises=ValidationError)
+def test_missing_fully_connected(valid_input):
+    valid_input.pop("fullyConnected")
+    assert DeviceConnectivity.parse_raw_schema(json.dumps(valid_input))
+
+
+@pytest.mark.xfail(raises=ValidationError)
+def test_missing_graphy(valid_input):
+    valid_input.pop("connectivityGraph")
+    DeviceConnectivity.parse_raw_schema(json.dumps(valid_input))

--- a/test/braket/device_schema/test_device_execution_window_v1.py
+++ b/test/braket/device_schema/test_device_execution_window_v1.py
@@ -1,0 +1,57 @@
+# Copyright 2019-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+import json
+import pdb
+
+import pytest
+from pydantic import ValidationError
+
+from braket.device_schema.device_execution_window_v1 import DeviceExecutionWindow, ExecutionDay
+
+
+@pytest.fixture(scope="module")
+def valid_input():
+    input = {
+        "braketSchemaHeader": {
+            "name": "braket.device_schema.device_execution_window",
+            "version": "1",
+        },
+        "executionDay": "Everyday",
+        "windowStartHour": "1966280412345.6789",
+        "windowEndHour": "1966280414345.6789",
+    }
+    return input
+
+
+def test_valid(valid_input):
+    result = DeviceExecutionWindow.parse_raw_schema(json.dumps(valid_input))
+    assert result.executionDay == ExecutionDay("Everyday")
+
+
+@pytest.mark.xfail(raises=ValidationError)
+def test__missing_schemaHeader(valid_input):
+    valid_input.pop("braketSchemaHeader")
+    assert DeviceExecutionWindow.parse_raw_schema(json.dumps(valid_input))
+
+
+@pytest.mark.xfail(raises=ValidationError)
+def test__missing_executionDay(valid_input):
+    valid_input.pop("executionDay")
+    assert DeviceExecutionWindow.parse_raw_schema(json.dumps(valid_input))
+
+
+@pytest.mark.xfail(raises=ValidationError)
+def test__invalid_executionDay(valid_input):
+    valid_input["executionDay"] = "today"
+    DeviceExecutionWindow.parse_raw_schema(json.dumps(valid_input))

--- a/test/braket/device_schema/test_device_paradigm_properties_v1.py
+++ b/test/braket/device_schema/test_device_paradigm_properties_v1.py
@@ -1,0 +1,41 @@
+# Copyright 2019-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from braket.device_schema.device_paradigm_properties_v1 import DeviceParadigmProperties
+
+
+@pytest.fixture(scope="module")
+def valid_input():
+    input = {
+        "braketSchemaHeader": {
+            "name": "braket.device_schema.device_paradigm_properties",
+            "version": "1",
+        }
+    }
+    return input
+
+
+def test_valid(valid_input):
+    result = DeviceParadigmProperties.parse_raw_schema(json.dumps(valid_input))
+    assert result.braketSchemaHeader.name == "braket.device_schema.device_paradigm_properties"
+
+
+@pytest.mark.xfail(raises=ValidationError)
+def test_missing_schema_header(valid_input):
+    valid_input.pop("braketSchemaHeader")
+    DeviceParadigmProperties.parse_raw_schema(json.dumps(valid_input))

--- a/test/braket/device_schema/test_device_parameters_v1.py
+++ b/test/braket/device_schema/test_device_parameters_v1.py
@@ -1,0 +1,76 @@
+# Copyright 2019-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+import json
+import pdb
+
+import pytest
+from pydantic import ValidationError
+
+from braket.device_schema.device_parameters_v1 import DeviceParameters
+
+
+@pytest.fixture(scope="module")
+def valid_gate_model_input():
+    input = {
+        "braketSchemaHeader": {"name": "braket.device_schema.device_parameters", "version": "1",},
+        "deviceParameters": {
+            "braketSchemaHeader": {
+                "name": "braket.device_schema.gate_model_parameters",
+                "version": "1",
+            }
+        },
+    }
+    return input
+
+
+@pytest.fixture(scope="module")
+def valid_annealing_model_input():
+    input = {
+        "braketSchemaHeader": {"name": "braket.device_schema.device_parameters", "version": "1",},
+        "deviceParameters": {
+            "braketSchemaHeader": {
+                "name": "braket.device_schema.annealing_model_parameters",
+                "version": "1",
+            },
+            "dWaveParameters": {
+                "braketSchemaHeader": {
+                    "name": "braket.device_schema.d_wave_parameters",
+                    "version": "1",
+                }
+            },
+        },
+    }
+    return input
+
+
+def test_valid_gate_model(valid_gate_model_input):
+    result = DeviceParameters.parse_raw_schema(json.dumps(valid_gate_model_input))
+    assert result.braketSchemaHeader.name == "braket.device_schema.device_parameters"
+
+
+def test_valid_annealing_model(valid_annealing_model_input):
+    result = DeviceParameters.parse_raw_schema(json.dumps(valid_annealing_model_input))
+    assert result.braketSchemaHeader.name == "braket.device_schema.device_parameters"
+
+
+@pytest.mark.xfail(raises=ValidationError)
+def test__missing_schemaHeader(valid_gate_model_input):
+    valid_gate_model_input.pop("braketSchemaHeader")
+    DeviceParameters.parse_raw_schema(json.dumps(valid_gate_model_input))
+
+
+@pytest.mark.xfail(raises=ValidationError)
+def test_missing_both_model(valid_gate_model_input):
+    valid_gate_model_input["deviceParameters"] = []
+    DeviceParameters.parse_raw_schema(json.dumps(valid_gate_model_input))

--- a/test/braket/device_schema/test_device_service_properties_v1.py
+++ b/test/braket/device_schema/test_device_service_properties_v1.py
@@ -1,0 +1,66 @@
+# Copyright 2019-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+import json
+import pdb
+
+import pytest
+from pydantic import ValidationError
+
+from braket.device_schema.device_service_properties_v1 import DeviceServiceProperties
+
+
+@pytest.fixture(scope="module")
+def valid_input():
+    input = {
+        "braketSchemaHeader": {
+            "name": "braket.device_schema.device_service_properties",
+            "version": "1",
+        },
+        "executionWindows": [
+            {
+                "braketSchemaHeader": {
+                    "name": "braket.device_schema.device_execution_window",
+                    "version": "1",
+                },
+                "executionDay": "Everyday",
+                "windowStartHour": "1966280412345.6789",
+                "windowEndHour": "1966280414345.6789",
+            }
+        ],
+        "shots": 2,
+    }
+    return input
+
+
+def test_valid(valid_input):
+    result = DeviceServiceProperties.parse_raw_schema(json.dumps(valid_input))
+    assert result.shots == 2
+
+
+@pytest.mark.xfail(raises=ValidationError)
+def test__missing_schemaHeader(valid_input):
+    valid_input.pop("braketSchemaHeader")
+    assert DeviceServiceProperties.parse_raw_schema(json.dumps(valid_input))
+
+
+@pytest.mark.xfail(raises=ValidationError)
+def test__missing_executionWindows(valid_input):
+    valid_input.pop("executionWindows")
+    assert DeviceServiceProperties.parse_raw_schema(json.dumps(valid_input))
+
+
+@pytest.mark.xfail(raises=ValidationError)
+def test__missing_shots(valid_input):
+    valid_input.pop("shots")
+    DeviceServiceProperties.parse_raw_schema(json.dumps(valid_input))

--- a/test/braket/device_schema/test_gate_model_parameters_v1.py
+++ b/test/braket/device_schema/test_gate_model_parameters_v1.py
@@ -1,0 +1,32 @@
+# Copyright 2019-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+import pytest
+from pydantic import ValidationError
+
+from braket.device_schema.gate_model_parameters_v1 import GateModelParameters
+
+
+def test_valid():
+    input = (
+        '{"braketSchemaHeader": {"name": "braket.device_schema.gate_model_parameters", '
+        '"version": "1"}} '
+    )
+    result = GateModelParameters.parse_raw_schema(input)
+    assert result.braketSchemaHeader.name == "braket.device_schema.gate_model_parameters"
+
+
+@pytest.mark.xfail(raises=ValidationError)
+def test__missing_schemaHeader():
+    input = {"qubitCount": 1}
+    assert GateModelParameters.parse_raw_schema(input)

--- a/test/braket/device_schema/test_ion_q_device_capabilities_v1.py
+++ b/test/braket/device_schema/test_ion_q_device_capabilities_v1.py
@@ -1,0 +1,121 @@
+# Copyright 2019-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+import json
+import pdb
+
+import pytest
+from pydantic import ValidationError
+
+from braket.device_schema.ion_q_device_capabilities_v1 import IonQDeviceCapabilities
+
+
+@pytest.fixture(scope="module")
+def valid_input():
+    input = {
+        "braketSchemaHeader": {
+            "name": "braket.device_schema.ion_q_device_capabilities",
+            "version": "1",
+        },
+        "service": {
+            "braketSchemaHeader": {
+                "name": "braket.device_schema.device_service_properties",
+                "version": "1",
+            },
+            "executionWindows": [
+                {
+                    "braketSchemaHeader": {
+                        "name": "braket.device_schema.device_execution_window",
+                        "version": "1",
+                    },
+                    "executionDay": "Everyday",
+                    "windowStartHour": "1966280412345.6789",
+                    "windowEndHour": "1966280414345.6789",
+                }
+            ],
+            "shots": 2,
+        },
+        "action": {
+            "braket.ir.jaqcd.program": {
+                "braketSchemaHeader": {
+                    "name": "braket.device_schema.jaqcd_device_action_properties",
+                    "version": "1",
+                },
+                "actionType": "braket.ir.jaqcd.program",
+                "version": ["1.0", "1.1"],
+                "supportedOperations": [{"control": 0, "target": 1, "type": "cnot"}],
+                "supportedResultTypes": [
+                    {"observable": ["x"], "targets": [1], "type": "expectation"}
+                ],
+            }
+        },
+        "paradigm": {
+            "braketSchemaHeader": {
+                "name": "braket.device_schema.ion_q_device_paradigm_properties",
+                "version": "1",
+            },
+            "qubitCount": 11,
+            "nativeGateSet": ["ccnot", "cy"],
+            "connectivity": {
+                "braketSchemaHeader": {
+                    "name": "braket.device_schema.device_connectivity",
+                    "version": "1",
+                },
+                "fullyConnected": True,
+                "connectivityGraph": {"1": ["2", "3"]},
+            },
+        },
+        "deviceParameters": {
+            "braketSchemaHeader": {
+                "name": "braket.device_schema.ion_q_device_parameters",
+                "version": "1",
+            },
+            "qubitCount": 11,
+        },
+    }
+    return input
+
+
+def test_valid(valid_input):
+    result = IonQDeviceCapabilities.parse_raw_schema(json.dumps(valid_input))
+    assert result.braketSchemaHeader.name == "braket.device_schema.ion_q_device_capabilities"
+
+
+@pytest.mark.xfail(raises=ValidationError)
+def test__missing_schemaHeader(valid_input):
+    valid_input.pop("braketSchemaHeader")
+    IonQDeviceCapabilities.parse_raw_schema(json.dumps(valid_input))
+
+
+@pytest.mark.xfail(raises=ValidationError)
+def test_missing_paradigm(valid_input):
+    valid_input.pop("paradigm")
+    IonQDeviceCapabilities.parse_raw_schema(json.dumps(valid_input))
+
+
+@pytest.mark.xfail(raises=ValidationError)
+def test_missing_deviceParameters(valid_input):
+    valid_input.pop("deviceParameters")
+    IonQDeviceCapabilities.parse_raw_schema(json.dumps(valid_input))
+
+
+@pytest.mark.xfail(raises=ValidationError)
+def test_missing_action(valid_input):
+    valid_input.pop("action")
+    IonQDeviceCapabilities.parse_raw_schema(json.dumps(valid_input))
+
+
+@pytest.mark.xfail(raises=ValidationError)
+def test_missing_service(valid_input):
+    valid_input.pop("service")
+    IonQDeviceCapabilities.parse_raw_schema(json.dumps(valid_input))

--- a/test/braket/device_schema/test_ion_q_device_paradigm_properties_v1.py
+++ b/test/braket/device_schema/test_ion_q_device_paradigm_properties_v1.py
@@ -1,0 +1,64 @@
+# Copyright 2019-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+import json
+import pdb
+
+import pytest
+from pydantic import ValidationError
+
+from braket.device_schema.ion_q_device_paradigm_properties_v1 import IonQDeviceParadigmProperties
+
+
+@pytest.fixture(scope="module")
+def valid_input():
+    input = {
+        "braketSchemaHeader": {
+            "name": "braket.device_schema.ion_q_device_paradigm_properties",
+            "version": "1",
+        },
+        "qubitCount": 32,
+        "nativeGateSet": ["ccnot", "cy"],
+        "connectivity": {
+            "braketSchemaHeader": {
+                "name": "braket.device_schema.device_connectivity",
+                "version": "1",
+            },
+            "fullyConnected": True,
+            "connectivityGraph": {"1": ["2", "3"]},
+        },
+    }
+    return input
+
+
+def test_valid(valid_input):
+    result = IonQDeviceParadigmProperties.parse_raw_schema(json.dumps(valid_input))
+    assert result.nativeGateSet == ["ccnot", "cy"]
+
+
+@pytest.mark.xfail(raises=ValidationError)
+def test__missing_schemaHeader(valid_input):
+    valid_input.pop("braketSchemaHeader")
+    IonQDeviceParadigmProperties.parse_raw_schema(json.dumps(valid_input))
+
+
+@pytest.mark.xfail(raises=ValidationError)
+def test__missing_qubitCount(valid_input):
+    valid_input.pop("qubitCount")
+    IonQDeviceParadigmProperties.parse_raw_schema(json.dumps(valid_input))
+
+
+@pytest.mark.xfail(raises=ValidationError)
+def test__invalid_connectivity(valid_input):
+    valid_input["connectivity"]["fullyConnected"] = 1
+    IonQDeviceParadigmProperties.parse_raw_schema(json.dumps(valid_input))

--- a/test/braket/device_schema/test_ion_q_device_parameters_v1.py
+++ b/test/braket/device_schema/test_ion_q_device_parameters_v1.py
@@ -1,0 +1,50 @@
+# Copyright 2019-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+import pytest
+from pydantic import ValidationError
+
+from braket.device_schema.ion_q_device_parameters_v1 import IonQDeviceParameters
+
+
+def test_valid():
+    input = (
+        '{"braketSchemaHeader": {"name": "braket.device_schema.ion_q_device_parameters", '
+        '"version": "1"}, "qubitCount": 11} '
+    )
+    result = IonQDeviceParameters.parse_raw_schema(input)
+    assert result.qubitCount == 11
+
+
+@pytest.mark.xfail(raises=ValidationError)
+def test__missing_schemaHeader():
+    input = {"qubitCount": 1}
+    assert IonQDeviceParameters.parse_raw_schema(input)
+
+
+@pytest.mark.xfail(raises=ValidationError)
+def test__missing_qubitCount():
+    input = (
+        '{"braketSchemaHeader": {"name": "braket.device_schema.ion_q_device_parameters", '
+        '"version": "1"}} '
+    )
+    assert IonQDeviceParameters.parse_raw_schema(input)
+
+
+@pytest.mark.xfail(raises=ValidationError)
+def test_invalid_qubitCount():
+    input = (
+        '{"braketSchemaHeader": {"name": "braket.device_schema.ion_q_device_parameters", '
+        '"version": "1"}, "qubitCount": -1} '
+    )
+    IonQDeviceParameters.parse_raw_schema(input)

--- a/test/braket/device_schema/test_jaqcd_device_action_properties_v1.py
+++ b/test/braket/device_schema/test_jaqcd_device_action_properties_v1.py
@@ -1,0 +1,58 @@
+# Copyright 2019-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+import json
+import pdb
+
+import pytest
+from pydantic import ValidationError
+
+from braket.device_schema.jaqcd_device_action_properties_v1 import JaqcdDeviceActionProperties
+
+
+@pytest.fixture(scope="module")
+def valid_input():
+    input = {
+        "braketSchemaHeader": {
+            "name": "braket.device_schema.jaqcd_device_action_properties",
+            "version": "1",
+        },
+        "actionType": "braket.ir.jaqcd.program",
+        "version": ["1.0", "1.1"],
+        "supportedOperations": [{"control": 0, "target": 1, "type": "cnot"}],
+        "supportedResultTypes": [{"observable": ["x"], "targets": [1], "type": "expectation"}],
+    }
+    return input
+
+
+def test_valid(valid_input):
+    result = JaqcdDeviceActionProperties.parse_raw_schema(json.dumps(valid_input))
+    assert result.actionType == "braket.ir.jaqcd.program"
+
+
+@pytest.mark.xfail(raises=ValidationError)
+def test__missing_schema_header(valid_input):
+    valid_input.pop("braketSchemaHeader")
+    JaqcdDeviceActionProperties.parse_raw_schema(json.dumps(valid_input))
+
+
+@pytest.mark.xfail(raises=ValidationError)
+def test_missing_action_type(valid_input):
+    valid_input.pop("actionType")
+    JaqcdDeviceActionProperties.parse_raw_schema(json.dumps(valid_input))
+
+
+@pytest.mark.xfail(raises=ValidationError)
+def test_invalid_supported_operations(valid_input):
+    valid_input.pop("supportedOperations")
+    JaqcdDeviceActionProperties.parse_raw_schema(json.dumps(valid_input))

--- a/test/braket/device_schema/test_rigetti_device_capabilities_v1.py
+++ b/test/braket/device_schema/test_rigetti_device_capabilities_v1.py
@@ -1,0 +1,121 @@
+# Copyright 2019-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+import json
+import pdb
+
+import pytest
+from pydantic import ValidationError
+
+from braket.device_schema.rigetti_device_capabilities_v1 import RigettiDeviceCapabilities
+
+
+@pytest.fixture(scope="module")
+def valid_input():
+    input = {
+        "braketSchemaHeader": {
+            "name": "braket.device_schema.rigetti_device_capabilities",
+            "version": "1",
+        },
+        "service": {
+            "braketSchemaHeader": {
+                "name": "braket.device_schema.device_service_properties",
+                "version": "1",
+            },
+            "executionWindows": [
+                {
+                    "braketSchemaHeader": {
+                        "name": "braket.device_schema.device_execution_window",
+                        "version": "1",
+                    },
+                    "executionDay": "Everyday",
+                    "windowStartHour": "1966280412345.6789",
+                    "windowEndHour": "1966280414345.6789",
+                }
+            ],
+            "shots": 2,
+        },
+        "action": {
+            "braket.ir.jaqcd.program": {
+                "braketSchemaHeader": {
+                    "name": "braket.device_schema.jaqcd_device_action_properties",
+                    "version": "1",
+                },
+                "actionType": "braket.ir.jaqcd.program",
+                "version": ["1.0", "1.1"],
+                "supportedOperations": [{"control": 0, "target": 1, "type": "cnot"}],
+                "supportedResultTypes": [
+                    {"observable": ["x"], "targets": [1], "type": "expectation"}
+                ],
+            }
+        },
+        "paradigm": {
+            "braketSchemaHeader": {
+                "name": "braket.device_schema.rigetti_device_paradigm_properties",
+                "version": "1",
+            },
+            "qubitCount": 32,
+            "nativeGateSet": ["ccnot", "cy"],
+            "connectivity": {
+                "braketSchemaHeader": {
+                    "name": "braket.device_schema.device_connectivity",
+                    "version": "1",
+                },
+                "fullyConnected": True,
+                "connectivityGraph": {"1": ["2", "3"]},
+            },
+        },
+        "deviceParameters": {
+            "braketSchemaHeader": {
+                "name": "braket.device_schema.rigetti_device_parameters",
+                "version": "1",
+            },
+            "qubitCount": 30,
+        },
+    }
+    return input
+
+
+def test_valid(valid_input):
+    result = RigettiDeviceCapabilities.parse_raw_schema(json.dumps(valid_input))
+    assert result.braketSchemaHeader.name == "braket.device_schema.rigetti_device_capabilities"
+
+
+@pytest.mark.xfail(raises=ValidationError)
+def test__missing_schemaHeader(valid_input):
+    valid_input.pop("braketSchemaHeader")
+    RigettiDeviceCapabilities.parse_raw_schema(json.dumps(valid_input))
+
+
+@pytest.mark.xfail(raises=ValidationError)
+def test_missing_paradigm(valid_input):
+    valid_input.pop("paradigm")
+    RigettiDeviceCapabilities.parse_raw_schema(json.dumps(valid_input))
+
+
+@pytest.mark.xfail(raises=ValidationError)
+def test_missing_deviceParameters(valid_input):
+    valid_input.pop("deviceParameters")
+    RigettiDeviceCapabilities.parse_raw_schema(json.dumps(valid_input))
+
+
+@pytest.mark.xfail(raises=ValidationError)
+def test_missing_action(valid_input):
+    valid_input.pop("action")
+    RigettiDeviceCapabilities.parse_raw_schema(json.dumps(valid_input))
+
+
+@pytest.mark.xfail(raises=ValidationError)
+def test_missing_service(valid_input):
+    valid_input.pop("service")
+    RigettiDeviceCapabilities.parse_raw_schema(json.dumps(valid_input))

--- a/test/braket/device_schema/test_rigetti_device_paradigm_properties_v1.py
+++ b/test/braket/device_schema/test_rigetti_device_paradigm_properties_v1.py
@@ -1,0 +1,66 @@
+# Copyright 2019-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+import json
+import pdb
+
+import pytest
+from pydantic import ValidationError
+
+from braket.device_schema.rigetti_device_paradigm_properties_v1 import (
+    RigettiDeviceParadigmProperties,
+)
+
+
+@pytest.fixture(scope="module")
+def valid_input():
+    input = {
+        "braketSchemaHeader": {
+            "name": "braket.device_schema.rigetti_device_paradigm_properties",
+            "version": "1",
+        },
+        "qubitCount": 32,
+        "nativeGateSet": ["ccnot", "cy"],
+        "connectivity": {
+            "braketSchemaHeader": {
+                "name": "braket.device_schema.device_connectivity",
+                "version": "1",
+            },
+            "fullyConnected": True,
+            "connectivityGraph": {"1": ["2", "3"]},
+        },
+    }
+    return input
+
+
+def test_valid(valid_input):
+    result = RigettiDeviceParadigmProperties.parse_raw_schema(json.dumps(valid_input))
+    assert result.nativeGateSet == ["ccnot", "cy"]
+
+
+@pytest.mark.xfail(raises=ValidationError)
+def test__missing_schemaHeader(valid_input):
+    valid_input.pop("braketSchemaHeader")
+    RigettiDeviceParadigmProperties.parse_raw_schema(json.dumps(valid_input))
+
+
+@pytest.mark.xfail(raises=ValidationError)
+def test__missing_qubitCount(valid_input):
+    valid_input.pop("qubitCount")
+    RigettiDeviceParadigmProperties.parse_raw_schema(json.dumps(valid_input))
+
+
+@pytest.mark.xfail(raises=ValidationError)
+def test__invalid_connectivity(valid_input):
+    valid_input["connectivity"]["fullyConnected"] = 1
+    RigettiDeviceParadigmProperties.parse_raw_schema(json.dumps(valid_input))

--- a/test/braket/device_schema/test_rigetti_device_parameters_v1.py
+++ b/test/braket/device_schema/test_rigetti_device_parameters_v1.py
@@ -1,0 +1,50 @@
+# Copyright 2019-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+import pytest
+from pydantic import ValidationError
+
+from braket.device_schema.rigetti_device_parameters_v1 import RigettiDeviceParameters
+
+
+def test_valid():
+    input = (
+        '{"braketSchemaHeader": {"name": "braket.device_schema.rigetti_device_parameters", '
+        '"version": "1"}, "qubitCount": 30} '
+    )
+    result = RigettiDeviceParameters.parse_raw_schema(input)
+    assert result.qubitCount == 30
+
+
+@pytest.mark.xfail(raises=ValidationError)
+def test__missing_schemaHeader():
+    input = {"qubitCount": 1}
+    assert RigettiDeviceParameters.parse_raw_schema(input)
+
+
+@pytest.mark.xfail(raises=ValidationError)
+def test__missing_qubitCount():
+    input = (
+        '{"braketSchemaHeader": {"name": "braket.device_schema.rigetti_device_parameters", '
+        '"version": "1"}} '
+    )
+    assert RigettiDeviceParameters.parse_raw_schema(input)
+
+
+@pytest.mark.xfail(raises=ValidationError)
+def test__invalid_qubitCount():
+    input = (
+        '{"braketSchemaHeader": {"name": "braket.device_schema.rigetti_device_parameters", '
+        '"version": "1"}, "qubitCount": 32} '
+    )
+    RigettiDeviceParameters.parse_raw_schema(input)


### PR DESCRIPTION
*Description of changes:*

Creating a schema for devices which will be used to validate the user input requests to CreateQuantumTask and also a contract between customers and DeviceService for exposing the device properties.

Tests: 
Added tests for each schema
