### PR TITLE
Add simulator metadata for task result

### DIFF
--- a/src/braket/ir/_version.py
+++ b/src/braket/ir/_version.py
@@ -15,4 +15,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.2.8"
+__version__ = "0.2.9"

--- a/src/braket/task_result/additional_metadata.py
+++ b/src/braket/task_result/additional_metadata.py
@@ -19,6 +19,7 @@ from braket.ir.annealing import Problem
 from braket.ir.jaqcd import Program
 from braket.task_result.dwave_metadata_v1 import DwaveMetadata
 from braket.task_result.rigetti_metadata_v1 import RigettiMetadata
+from braket.task_result.simulator_metadata_v1 import SimulatorMetadata
 
 
 class AdditionalMetadata(BaseModel):
@@ -38,3 +39,4 @@ class AdditionalMetadata(BaseModel):
     action: Union[Program, Problem]
     dwaveMetadata: Optional[DwaveMetadata]
     rigettiMetadata: Optional[RigettiMetadata]
+    simulatorMetadata: Optional[SimulatorMetadata]

--- a/src/braket/task_result/simulator_metadata_v1.py
+++ b/src/braket/task_result/simulator_metadata_v1.py
@@ -1,0 +1,40 @@
+# Copyright 2019-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License
+
+from pydantic import Field, conint
+
+from braket.schema_common import BraketSchemaBase, BraketSchemaHeader
+
+
+class SimulatorMetadata(BraketSchemaBase):
+    """
+    The simulator metadata result schema.
+
+    Attributes:
+        braketSchemaHeader (BraketSchemaHeader): Schema header.
+            Users do not need to set this value. Only default is allowed.
+        executionDuration (int): The number of milliseconds it took to execute
+            the circuit on the simulator.
+
+    Examples:
+        >>> SimulatorMetadata(executionDuration=100)
+
+    """
+
+    _SIMULATOR_METADATA_HEADER = BraketSchemaHeader(
+        name="braket.task_result.simulator_metadata", version="1"
+    )
+    braketSchemaHeader: BraketSchemaHeader = Field(
+        default=_SIMULATOR_METADATA_HEADER, const=_SIMULATOR_METADATA_HEADER
+    )
+    executionDuration: conint(ge=0)

--- a/test/braket/task_result/conftest.py
+++ b/test/braket/task_result/conftest.py
@@ -124,3 +124,8 @@ def shots():
 @pytest.fixture
 def task_metadata(id, device_id, shots):
     return TaskMetadata(id=id, deviceId=device_id, shots=shots)
+
+
+@pytest.fixture
+def execution_duration():
+    return 100

--- a/test/braket/task_result/test_simulator_metadata_v1.py
+++ b/test/braket/task_result/test_simulator_metadata_v1.py
@@ -1,0 +1,40 @@
+# Copyright 2019-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+import pytest
+from pydantic import ValidationError
+
+from braket.task_result.simulator_metadata_v1 import SimulatorMetadata
+
+
+@pytest.mark.xfail(raises=ValidationError)
+def test_missing_properties():
+    SimulatorMetadata()
+
+
+def test_simulator_metadata_correct(execution_duration):
+    metadata = SimulatorMetadata(executionDuration=execution_duration)
+    assert metadata.executionDuration == execution_duration
+    assert SimulatorMetadata.parse_raw(metadata.json()) == metadata
+    assert metadata == SimulatorMetadata.parse_raw_schema(metadata.json())
+
+
+@pytest.mark.xfail(raises=ValidationError)
+def test_execution_duration_incorrect():
+    execution_duration = -1
+    SimulatorMetadata(executionDuration=execution_duration)
+
+
+@pytest.mark.xfail(raises=ValidationError)
+def test_simulator_header_incorrect(braket_schema_header, execution_duration):
+    SimulatorMetadata(braketSchemaHeader=braket_schema_header, executionDuration=execution_duration)


### PR DESCRIPTION
**Issue**

**Description of changes:**
Adding simulator metadata in the task result schema. This includes execution duration.


**Build Results**

*Attach results of* `tox -e zip-build`
[build_files.tar.gz](https://github.com/aws/amazon-braket-schemas-python/files/5040093/build_files.tar.gz)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

