### PR TITLE
Updating the action type for dwave to annealing in doc/test

### DIFF
--- a/src/braket/device_schema/dwave/dwave_device_capabilities_v1.py
+++ b/src/braket/device_schema/dwave/dwave_device_capabilities_v1.py
@@ -87,8 +87,8 @@ class DwaveDeviceCapabilities(DeviceCapabilities, BraketSchemaBase):
         ...         "updatedAt": "2020-06-16T19:28:02.869136"
         ...    },
         ...    "action": {
-        ...        "braket.ir.jaqcd.program": {
-        ...            "actionType": "braket.ir.jaqcd.program",
+        ...        "braket.ir.annealing.problem": {
+        ...            "actionType": "braket.ir.annealing.problem",
         ...            "version": ["1.0", "1.1"],
         ...        }
         ...    },

--- a/test/braket/device_schema/dwave/test_dwave_device_capabilities_v1.py
+++ b/test/braket/device_schema/dwave/test_dwave_device_capabilities_v1.py
@@ -16,7 +16,7 @@ import json
 import pytest
 from pydantic import ValidationError
 
-from braket.device_schema.dwave.dwave_provider_properties_v1 import DwaveProviderProperties
+from braket.device_schema.dwave import DwaveDeviceCapabilities
 
 
 @pytest.fixture(scope="module")
@@ -73,8 +73,8 @@ def valid_input():
             "updatedAt": "2020-06-16T19:28:02.869136",
         },
         "action": {
-            "braket.ir.jaqcd.program": {
-                "actionType": "braket.ir.jaqcd.program",
+            "braket.ir.annealing.problem": {
+                "actionType": "braket.ir.annealing.problem",
                 "version": ["1.0", "1.1"],
             }
         },
@@ -101,17 +101,17 @@ def valid_input():
 
 
 def test_valid(valid_input):
-    result = DwaveProviderProperties.parse_raw_schema(json.dumps(valid_input))
+    result = DwaveDeviceCapabilities.parse_raw_schema(json.dumps(valid_input))
     assert result.provider.qubitCount == 1
 
 
 @pytest.mark.xfail(raises=ValidationError)
 def test__missing_schemaHeader(valid_input):
     valid_input.pop("braketSchemaHeader")
-    DwaveProviderProperties.parse_raw_schema(json.dumps(valid_input))
+    DwaveDeviceCapabilities.parse_raw_schema(json.dumps(valid_input))
 
 
 @pytest.mark.xfail(raises=ValidationError)
 def test_missing_qubitCount(valid_input):
     valid_input.pop("provider")
-    DwaveProviderProperties.parse_raw_schema(json.dumps(valid_input))
+    DwaveDeviceCapabilities.parse_raw_schema(json.dumps(valid_input))


### PR DESCRIPTION
**Description of changes:**
Update the examples and test input for dwave to use annealing action type. 

**Build Results**

*Attach results of* `tox -e zip-build`
[build_files.tar.gz](https://github.com/aws/amazon-braket-schemas-python/files/5042650/build_files.tar.gz)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

