### PR TITLE
adding provider attribute to device_capabilities

### DIFF
--- a/src/braket/device_schema/device_capabilities.py
+++ b/src/braket/device_schema/device_capabilities.py
@@ -11,7 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-from typing import Dict
+from typing import Dict, Optional
 
 from pydantic import BaseModel
 
@@ -30,6 +30,7 @@ class DeviceCapabilities(BaseModel):
             deviceParameters: It is the json schema of the deviceParameters for each device. for
                 example the deviceParameter for IonqDeviceCapabilities will be
                 IonqDeviceParameters.json_schema()
+            provider: optional dict which provides additional attributes specific to the provider
 
         Examples:
             >>> import json
@@ -66,6 +67,7 @@ class DeviceCapabilities(BaseModel):
             ...        }
             ...    },
             ...    "deviceParameters": {#Schema of specific device parameter instance},
+            ...    "provider": {}
             ... }
             >>> DeviceCapabilities.parse_raw(json.dumps(input_json))
     """
@@ -73,3 +75,4 @@ class DeviceCapabilities(BaseModel):
     service: DeviceServiceProperties
     action: Dict[DeviceActionType, DeviceActionProperties]
     deviceParameters: dict
+    provider: Optional[dict]


### PR DESCRIPTION
**Description of changes:**
Added provider as optional to device capabilities so we can show the customers the attributes that are specific to the device provider. 

**Build Results**

*Attach results of* `tox -e zip-build`

[build_files.tar.gz](https://github.com/aws/amazon-braket-schemas-python/files/5048219/build_files.tar.gz)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

