### PR TITLE
doc: change the sphinx requirement to be greater than 7.0.0

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,3 +1,3 @@
-sphinx
-sphinx-rtd-theme
+sphinx>7
+sphinx-rtd-theme>=1.3.0
 sphinxcontrib-apidoc


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Sphinx uses an older version of Sphinx in the [builds](https://readthedocs.org/projects/amazon-braket-default-simulator-python/builds/21915594/).

This PR is inspired by https://github.com/amazon-braket/amazon-braket-default-simulator-python/pull/209 

`python -m pip install --upgrade --no-cache-dir pillow mock==1.0.1 alabaster>=0.7,<0.8,!=0.7.5 commonmark==0.9.1 recommonmark==0.5.0 sphinx<2 sphinx-rtd-theme<0.5 readthedocs-sphinx-ext<2.3 jinja2<3.1.0`

> Sphinx:
>
>    Projects created before Oct 20, 2020 use 1.8.x. New projects use the latest version.


https://docs.readthedocs.io/en/stable/build-default-versions.html

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
