### PR TITLE
feature: adding active reset duration field to standard gate props v3

### DIFF
--- a/src/braket/device_schema/standardized_gate_model_qpu_device_properties_v3.py
+++ b/src/braket/device_schema/standardized_gate_model_qpu_device_properties_v3.py
@@ -120,6 +120,7 @@ class StandardizedGateModelQpuDeviceProperties(BraketSchemaBase):
         SingleQubitGateDuration (Optional[Duration]): The typical duration of a single-qubit gate operation.
         TwoQubitGateFidelity (Optional[list[Fidelity]]): The fidelity of two-qubit gate operation.
         TwoQubitGateDuration (Optional[Duration]): The typical duration of a two-qubit gate operation.
+        ActiveResetDuration (Optional[Duration]): Fixed duration to active reset a qubit.
     Examples:
         >>> import json
         >>> valid_input = {
@@ -204,6 +205,11 @@ class StandardizedGateModelQpuDeviceProperties(BraketSchemaBase):
         ...         "standardError": 0.000010,
         ...         "unit": "s"
         ...     },
+        ...     "activeResetDuration": {
+        ...         "value": 0.000100,
+        ...         "standardError": 0.000005,
+        ...         "unit": "s"
+        ...     },
         ...     "updatedAt": "2025-02-22T12:29:03Z"
         ... }
         >>> StandardizedGateModelQpuDeviceProperties.parse_raw_schema(json.dumps(valid_input))
@@ -222,4 +228,5 @@ class StandardizedGateModelQpuDeviceProperties(BraketSchemaBase):
     singleQubitFidelity: Optional[list[Fidelity]]
     twoQubitGateFidelity: Optional[list[Fidelity]]
     twoQubitGateDuration: Optional[Duration]
+    activeResetDuration: Optional[Duration]
     updatedAt: Optional[datetime]

--- a/test/unit_tests/braket/device_schema/test_standardized_gate_model_qpu_device_properties_v3.py
+++ b/test/unit_tests/braket/device_schema/test_standardized_gate_model_qpu_device_properties_v3.py
@@ -77,6 +77,11 @@ def test_parse_success():
             }
         ],
         "twoQubitGateDuration": {"value": 0.000200, "standardError": 0.000010, "unit": "s"},
+        "activeResetDuration": {
+            "value": 0.000100,
+            "standardError": 0.000005,
+            "unit": "s"
+        },
         "updatedAt": "2025-02-22T12:29:03Z",
     }
     assert StandardizedGateModelQpuDeviceProperties.parse_raw_schema(json.dumps(input))


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
adding active reset duration field to standard gate props v3

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-schemas-python/blob/main/CONTRIBUTING.md) doc
- [x ] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-schemas-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-schemas-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-schemas-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
