### PR TITLE
feat: add maximumOutput to OpenQASMDeviceActionProperties

### DIFF
--- a/src/braket/device_schema/openqasm_device_action_properties.py
+++ b/src/braket/device_schema/openqasm_device_action_properties.py
@@ -35,6 +35,9 @@ class OpenQASMDeviceActionProperties(DeviceActionProperties):
             OpenQASM action.
         requiresContiguousQubitIndices: Whether used qubit indices of qubit arrays
             are required to be contiguous.
+        maximumOutputs: Maximum number of output declarations allowed by the device.
+            A value of 0 indicates no output declarations are allowed, and None
+            indicates no limit.
 
     Examples:
         >>> import json
@@ -52,10 +55,11 @@ class OpenQASMDeviceActionProperties(DeviceActionProperties):
         ...    "supportedPragmas": ["braket_bit_flip_noise"],
         ...    "forbiddenPragmas": ["braket_kraus_operator"],
         ...    "forbiddenArrayOperations": ["concatenation", "range", "slicing"],
-        ...    "requiresAllQubitsMeasurement": False
-        ...    "requiresContiguousQubitIndices": False
-        ...    "supportsPartialVerbatimBox": False
-        ...    "supportsUnassignedMeasurements": True
+        ...    "requiresAllQubitsMeasurement": False,
+        ...    "requiresContiguousQubitIndices": False,
+        ...    "supportsPartialVerbatimBox": False,
+        ...    "supportsUnassignedMeasurements": True,
+        ...    "maximumOutputs": 0,
         ... }
         >>> OpenQASMDeviceActionProperties.parse_raw(json.dumps(input_json))
 
@@ -68,6 +72,7 @@ class OpenQASMDeviceActionProperties(DeviceActionProperties):
     forbiddenPragmas: list[str] | None = Field(default_factory=list)
     maximumQubitArrays: int | None = None  # None indicates no limit
     maximumClassicalArrays: int | None = None  # None indicates no limit
+    maximumOutputs: int | None = None  # None indicates no limit
     forbiddenArrayOperations: list[str] | None = Field(default_factory=list)
     requiresAllQubitsMeasurement: bool | None = False
     supportPhysicalQubits: bool | None = False

--- a/test/unit_tests/braket/device_schema/test_openqasm_device_action_properties.py
+++ b/test/unit_tests/braket/device_schema/test_openqasm_device_action_properties.py
@@ -119,6 +119,12 @@ def test_default_supported_modifiers(valid_input):
     assert result.supportedModifiers == []
 
 
+def test_default_maximum_output(valid_input):
+    valid_input.pop("maximumOutputs", None)
+    result = OpenQASMDeviceActionProperties.parse_raw(json.dumps(valid_input))
+    assert result.maximumOutputs == None
+
+
 @pytest.mark.xfail(raises=ValidationError)
 def test_missing_action_type(valid_input):
     valid_input.pop("actionType")


### PR DESCRIPTION
Adds an optional `maximumOutputs` field to `OpenQASMDeviceActionProperties` to specify the maximum number of OpenQASM output instructions a device allows.

- `maximumOutputs: int | None = None`
- `0` indicates no output instructions are allowed
- `None` indicates no limit

This change is purely additive and backward compatible. Existing payloads without the field parse successfully and default to `None`, so no schema version bump is required.